### PR TITLE
Added @type as metadata for Annotation

### DIFF
--- a/lapps.vocab
+++ b/lapps.vocab
@@ -35,6 +35,10 @@ Annotation {
 	        type "List of URI"
 	        description "The documentation (if any) for the rules that were used to identify the annotations."
 	    }
+	    type {
+	    	type "String"
+	    	description "The value type of the annotations produced."
+	    }
 	}
 	properties {
 		id {


### PR DESCRIPTION
The type field has been used in the `metadata.contains` section but has never been documented.

Closes #22