### PR TITLE
Added UD

### DIFF
--- a/lapps.discriminators
+++ b/lapps.discriminators
@@ -134,6 +134,10 @@ tcf {
     uri _xml('tcf')
     description "Text Corpus Format used by Weblicht services. See <link>https://weblicht.sfs.uni-tuebingen.de/weblichtwiki/index.php/The_TCF_Format</link>"
 }
+ud {
+	uri media('ud')
+	description "Universal Dependencies. See <link>http://universaldependencies.org</link>"
+}
 
 /*
  * Annotation types.


### PR DESCRIPTION
Added http://vocab.lappsgrid.org/ns/media/ud as the discriminator for Universal Dependencies.

See https://github.com/lapps/org.lappsgrid.discriminator/issues/11