### PR TITLE
Support aliases for XML Schema datatypes

### DIFF
--- a/Datatypes.schema
+++ b/Datatypes.schema
@@ -1,0 +1,36 @@
+
+/*
+ * Custom types used to generate the XML Schema. This format is actually
+ * XML Schema using a Groovy MarkupBuilder
+ */
+Datatypes {
+	simpleType('list_uri', 'List of URI') {
+	    restriction {
+	        simpleType {
+	            list itemType:'xs:anyURI'
+	        }
+	    }
+	}
+	simpleType('string_list') {
+		alias "List of String"
+		alias 'List of Strings'
+		restriction {
+			simpleType {
+				list itemType:'xs:string'
+			}
+		}
+	}
+	complexType('morphology') {
+	    sequence {
+	        element name:'majorWordClass', type:'xs:string'
+	        element name:'wordClass', type:'xs:string'
+	        element name:'prefix', type:'xs:string'
+	        element name:'suffix', type:'xs:string'
+	        element name:'number', type:'xs:string'
+	        element name:'person', type:'xs:string'
+	        element name:'syntax', type:'xs:string'
+	        element name:'tense', type:'xs:string'
+	    }
+	}
+}
+

--- a/lapps.vocabulary
+++ b/lapps.vocabulary
@@ -6,6 +6,8 @@
 schema="http://schema.org"
 iso="http://www.isocat.org/datcat"
 
+include "Datatypes.schema"
+
 /*
 version='1.2.9-SNAPSHOT'
 File versionFile = new File('VERSION')
@@ -47,7 +49,7 @@ Annotation {
 	sameAs "$iso/DC-2318"
 	metadata {
 	    producer {
-	        type XSD.list_uri
+	        type 'List of URI'
 	        description "The software that produced the annotations."
 	    }
 	    rules {
@@ -77,7 +79,7 @@ Region {
 	 property."""
 	properties {
 		targets {
-			type XSD.list_uri
+			type 'List of URI'
 			description """IDs of a sequence of annotations covering the region of primary data referred to by this annotation. Used as an alternative to <em>start</em> and <em>end</em> to point to component annotations (e.g., a token sequence) rather than directly into primary data, or to link two or more annotations."""
 		}
 		start {
@@ -609,37 +611,3 @@ AudioDocument {
     definition "Any electronic media content consisting of audio (language). An audio document may consist of several physical computer files."
     parent "Document"
 }
-
-/*
- * Custom types used to generate the XML Schema. This format is actually
- * XML Schema using a Groovy MarkupBuilder
- */
-Datatypes {
-	simpleType('list_uri') {
-	    restriction {
-	        simpleType {
-	            list itemType:'xs:anyURI'
-	        }
-	    }
-	}
-	simpleType('string_list') {
-		restriction {
-			simpleType {
-				list itemType:'xs:string'
-			}
-		}
-	}
-	complexType('morphology') {
-	    sequence {
-	        element name:'majorWordClass', type:'xs:string'
-	        element name:'wordClass', type:'xs:string'
-	        element name:'prefix', type:'xs:string'
-	        element name:'suffix', type:'xs:string'
-	        element name:'number', type:'xs:string'
-	        element name:'person', type:'xs:string'
-	        element name:'syntax', type:'xs:string'
-	        element name:'tense', type:'xs:string'
-	    }
-	}
-}
-


### PR DESCRIPTION
XML Schema datatypes are now defined in their own file (Datatypes.schema) which is *included* in the *lapps.vocabulary* file.

Defined datatypes can specify a human readable `alias` that is used in documentation.